### PR TITLE
Tune GEMM for Imagination GPU

### DIFF
--- a/include/dlprim/context.hpp
+++ b/include/dlprim/context.hpp
@@ -394,6 +394,8 @@ public:
     bool is_nvidia();
     /// checks if the device is Intel GPU
     bool is_intel();
+    /// checks if the device is Imagination GPU
+    bool is_imagination();
 
     /// Get OpenCL context object
     cl::Context &context()

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,6 +105,12 @@ namespace dlprim {
         return device().getInfo<CL_DEVICE_VENDOR_ID>() == 0x10DE;
         //return device_extensions().find("cl_nv_") != std::string::npos;
     }
+    bool Context::is_imagination()
+    {
+        if(is_cpu_context())
+            return false;
+        return device().getInfo<CL_DEVICE_VENDOR_ID>() == 0x1010;
+    }
 
     int Context::estimated_core_count()
     {

--- a/src/gemm.cpp
+++ b/src/gemm.cpp
@@ -41,6 +41,15 @@ namespace gpu {
                     tile_size_k_ = 16;
                     off_ = 0;
                 }
+                else if (ctx.is_imagination())
+                {
+                   tile_size_m_ = 64;
+                   tile_size_n_ = 64;
+                   block_size_m_ = 8;
+                   block_size_n_ = 8;
+                   tile_size_k_ = 16;
+                   off_ = 1;
+                }
                 else if(ctx.is_amd() && !actual_gemm) {
                     if(M >= 256 && N >= 256) {
                         tile_size_m_ = 96;


### PR DESCRIPTION
Adds is_imagination() check and optimized GEMM settings.

See: https://github.com/artyom-beilis/dlprimitives/discussions/29